### PR TITLE
feat: strict user permissions with notification, security & UX hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ css/style*
 build
 .wordpress-ripo
 .php-cs-fixer.cache
+*.tsbuildinfo
 dependencies
 assets/js
 assets/libs

--- a/backend/app/Config.php
+++ b/backend/app/Config.php
@@ -21,7 +21,7 @@ class Config
 
     const VAR_PREFIX = 'bitapps_fm_';
 
-    const VERSION = '6.8.9';
+    const VERSION = '6.9';
 
     const VERSION_ID = 689;
 

--- a/backend/app/Config.php
+++ b/backend/app/Config.php
@@ -167,6 +167,19 @@ class Config
         return is_readable(Config::get('BASEDIR') . '/port');
     }
 
+    public static function devPort(): int
+    {
+        if (!self::isDev()) {
+            return 0;
+        }
+
+        $port = (int) file_get_contents(Config::get('BASEDIR') . '/port');
+
+        // Reject privileged/out-of-range ports so a planted port file can't aim
+        // script loads at other services.
+        return ($port >= 1024 && $port <= 65535) ? $port : 0;
+    }
+
     public static function adBanner()
     {
         $hideAT  = new DateTimeImmutable('2024-03-31');

--- a/backend/app/Http/Controllers/FileManagerController.php
+++ b/backend/app/Http/Controllers/FileManagerController.php
@@ -245,23 +245,25 @@ final class FileManagerController
     {
         $permissions = Plugin::instance()->permissions();
 
-        $roleCommands  = $permissions->getByRole($permissions->currentUserRole())['commands'];
-        $userCommands  = $permissions->permissionsForCurrentUser()['commands'];
-        $unionCommands = $permissions->getEnabledCommandsUnion();
+        $role             = $permissions->currentUserRole();
+        $permissionByRole = $permissions->getByRole($role);
+        $roleCommands     = $permissionByRole['commands'];
+        $userCommands     = $permissions->permissionsForCurrentUser()['commands'];
+        $unionCommands    = $permissions->getEnabledCommandsUnion();
+        $publicPath       = $permissions->getPathByFolderOption();
 
         // Public volume may nest the per-user folder: use the least-restrictive hint
         // so nothing legitimate is hidden; the runtime gate enforces per path.
         $roots[] = $this->processFileRoot(
-            $permissions->getPathByFolderOption(),
+            $publicPath,
             'Public',
-            $this->getUrlByPath($permissions->getPathByFolderOption()),
+            $this->getUrlByPath($publicPath),
             $permissions->getDisabledCommandFor($unionCommands)
         );
 
-        $permissionByRole = $permissions->getByRole($permissions->currentUserRole());
-        $roots[]          = $this->processFileRoot(
+        $roots[] = $this->processFileRoot(
             $permissionByRole['path'],
-            $permissions->currentUserRole(),
+            $role,
             $this->getUrlByPath($permissionByRole['path']),
             $permissions->getDisabledCommandFor($roleCommands)
         );

--- a/backend/app/Http/Controllers/FileManagerController.php
+++ b/backend/app/Http/Controllers/FileManagerController.php
@@ -53,7 +53,7 @@ final class FileManagerController
         );
 
         $finderOptions->setBind(
-            'get.pre file.pre archive.pre back.pre chmod.pre colwidth.pre copy.pre cut.pre duplicate.pre editor.pre
+            'get.pre put.pre file.pre archive.pre back.pre chmod.pre colwidth.pre copy.pre cut.pre duplicate.pre editor.pre
              extract.pre forward.pre fullscreen.pre getfile.pre help.pre home.pre info.pre mkdir.pre mkfile.pre
              netmount.pre netunmount.pre open.pre opendir.pre paste.pre places.pre quicklook.pre reload.pre
              rename.pre resize.pre restore.pre rm.pre search.pre sort.pre up.pre upload.pre view.pre zipdl.pre

--- a/backend/app/Http/Controllers/FileManagerController.php
+++ b/backend/app/Http/Controllers/FileManagerController.php
@@ -85,10 +85,6 @@ final class FileManagerController
             $finderOptions->setCommonTempPath(Config::uploadBaseDir() . '/.tmp/');
         }
 
-        if (fileSystemAdapter()->is_writable(Config::uploadBaseDir() . '/.tmb/')) {
-            $finderOptions->setThumbPath(Config::uploadBaseDir() . '/.tmb/');
-        }
-
         $allVolumes         = $this->getFileRoots();
         $volumeCount        = \count($allVolumes);
         $invalidVolumeCount = 0;
@@ -221,10 +217,6 @@ final class FileManagerController
             $this->setAllowedFileType($baseRoot);
         }
 
-        if (fileSystemAdapter()->is_writable(stripslashes($preferences->getRootPath()) . DIRECTORY_SEPARATOR . '.tmbPath')) {
-            $baseRoot->setOption('tmbPath', Config::uploadBaseDir() . '/.tmb/');
-        }
-
         $baseRoot->setAccessControl([$accessControlProvider, 'control']);
         $baseRoot->setAcceptedName([$accessControlProvider, 'validateName']);
         $baseRoot->setDisabled([]);
@@ -247,36 +239,28 @@ final class FileManagerController
 
         $role             = $permissions->currentUserRole();
         $permissionByRole = $permissions->getByRole($role);
-        $roleCommands     = $permissionByRole['commands'];
-        $userCommands     = $permissions->permissionsForCurrentUser()['commands'];
-        $unionCommands    = $permissions->getEnabledCommandsUnion();
+        $permissionByUser = $permissions->getByUser($permissions->currentUserID());
         $publicPath       = $permissions->getPathByFolderOption();
 
-        // Public volume may nest the per-user folder: use the least-restrictive hint
-        // so nothing legitimate is hidden; the runtime gate enforces per path.
         $roots[] = $this->processFileRoot(
             $publicPath,
             'Public',
             $this->getUrlByPath($publicPath),
-            $permissions->getDisabledCommandFor($unionCommands)
+            $permissions->getPublicVolumeDisabledCommands()
         );
 
         $roots[] = $this->processFileRoot(
             $permissionByRole['path'],
             $role,
             $this->getUrlByPath($permissionByRole['path']),
-            $permissions->getDisabledCommandFor($roleCommands)
+            $permissions->getRoleVolumeDisabledCommands()
         );
 
-        $permissionByUser = $permissions->getByUser($permissions->currentUserID());
-        $userHint         = $permissions->isCurrentUserHasPermission()
-            ? $permissions->getDisabledCommandFor($userCommands)
-            : $permissions->getDisabledCommandFor($roleCommands);
-        $roots[]          = $this->processFileRoot(
+        $roots[] = $this->processFileRoot(
             $permissionByUser['path'],
             $permissions->currentUser()->display_name,
             $this->getUrlByPath($permissionByUser['path']),
-            $userHint
+            $permissions->getUserVolumeDisabledCommands()
         );
 
         return $roots;

--- a/backend/app/Http/Controllers/FileManagerController.php
+++ b/backend/app/Http/Controllers/FileManagerController.php
@@ -243,26 +243,38 @@ final class FileManagerController
 
     private function getUserVolumes()
     {
-        $permissions           = Plugin::instance()->permissions();
+        $permissions = Plugin::instance()->permissions();
 
+        $roleCommands  = $permissions->getByRole($permissions->currentUserRole())['commands'];
+        $userCommands  = $permissions->permissionsForCurrentUser()['commands'];
+        $unionCommands = $permissions->getEnabledCommandsUnion();
+
+        // Public volume may nest the per-user folder: use the least-restrictive hint
+        // so nothing legitimate is hidden; the runtime gate enforces per path.
         $roots[] = $this->processFileRoot(
             $permissions->getPathByFolderOption(),
             'Public',
-            $this->getUrlByPath($permissions->getPathByFolderOption())
+            $this->getUrlByPath($permissions->getPathByFolderOption()),
+            $permissions->getDisabledCommandFor($unionCommands)
         );
 
-        $permissionByRole   = $permissions->getByRole($permissions->currentUserRole());
-        $roots[]            = $this->processFileRoot(
+        $permissionByRole = $permissions->getByRole($permissions->currentUserRole());
+        $roots[]          = $this->processFileRoot(
             $permissionByRole['path'],
             $permissions->currentUserRole(),
-            $this->getUrlByPath($permissionByRole['path'])
+            $this->getUrlByPath($permissionByRole['path']),
+            $permissions->getDisabledCommandFor($roleCommands)
         );
 
-        $permissionByUser   = $permissions->getByUser($permissions->currentUserID());
-        $roots[]            = $this->processFileRoot(
+        $permissionByUser = $permissions->getByUser($permissions->currentUserID());
+        $userHint         = $permissions->isCurrentUserHasPermission()
+            ? $permissions->getDisabledCommandFor($userCommands)
+            : $permissions->getDisabledCommandFor($roleCommands);
+        $roots[]          = $this->processFileRoot(
             $permissionByUser['path'],
             $permissions->currentUser()->display_name,
-            $this->getUrlByPath($permissionByUser['path'])
+            $this->getUrlByPath($permissionByUser['path']),
+            $userHint
         );
 
         return $roots;
@@ -289,13 +301,14 @@ final class FileManagerController
     /**
      * Create Instance of FileRoot
      *
-     * @param string $path
-     * @param string $alias
-     * @param string $url
+     * @param string     $path
+     * @param string     $alias
+     * @param string     $url
+     * @param array|null $disabledCommands Per-volume disabled-command hint; falls back to global when null.
      *
      * @return FileRoot
      */
-    private function processFileRoot($path, $alias, $url)
+    private function processFileRoot($path, $alias, $url, ?array $disabledCommands = null)
     {
         $permissions           = Plugin::instance()->permissions();
         $accessControlProvider = Plugin::instance()->accessControl();
@@ -308,7 +321,7 @@ final class FileManagerController
         $this->setAllowedFileType($volume);
         $volume->setAccessControl([$accessControlProvider, 'control']);
         $volume->setAcceptedName([$accessControlProvider, 'validateName']);
-        $volume->setDisabled($permissions->getDisabledCommand());
+        $volume->setDisabled($disabledCommands ?? $permissions->getDisabledCommand());
         $volume->setWinHashFix(DIRECTORY_SEPARATOR !== '/');
 
         if (Capabilities::filter(Config::VAR_PREFIX . 'user_can_manage_options')) {

--- a/backend/app/Http/Middleware/CapCheckerMiddleware.php
+++ b/backend/app/Http/Middleware/CapCheckerMiddleware.php
@@ -16,7 +16,10 @@ final class CapCheckerMiddleware
         if (!$cap || !Capabilities::filter($cap)) {
             echo wp_json_encode(
                 [
-                    'message' => __('You are not authorized to access this endpoint', 'file-manager'),
+                    'message' => __(
+                        "You don't have permission to access this. Please contact your site administrator.",
+                        'file-manager'
+                    ),
                     'code'    => 'NOT_AUTHORIZED',
                     'status'  => 'error',
                 ]

--- a/backend/app/Http/Rules/ValidPathRule.php
+++ b/backend/app/Http/Rules/ValidPathRule.php
@@ -7,6 +7,7 @@ if (! \defined('ABSPATH')) {
 }
 
 use BitApps\FM\Plugin;
+use BitApps\FM\Providers\PermissionsProvider;
 use BitApps\FM\Vendor\BitApps\WPValidator\Rule;
 
 class ValidPathRule extends Rule
@@ -15,17 +16,22 @@ class ValidPathRule extends Rule
 
     public function validate($value)
     {
-        $path    = Plugin::instance()->preferences()->realPath($value);
-        $isValid = false;
-        if (strpos($path, trim(ABSPATH, '/\\')) === false) {
+        $path   = Plugin::instance()->preferences()->realPath($value);
+        $target = \is_string($path) ? PermissionsProvider::realpathWithin($path, ABSPATH) : null;
+
+        if ($target === null) {
             $this->_message = __('Folder Path Must be within WordPress root directory', 'file-manager');
-        } elseif (!is_readable($path)) {
-            $this->_message = __('Please provide a readable folder path', 'file-manager');
-        } else {
-            $isValid = true;
+
+            return false;
         }
 
-        return $isValid;
+        if (!is_readable($target)) {
+            $this->_message = __('Please provide a readable folder path', 'file-manager');
+
+            return false;
+        }
+
+        return true;
     }
 
     public function message()

--- a/backend/app/Providers/AccessControlProvider.php
+++ b/backend/app/Providers/AccessControlProvider.php
@@ -103,14 +103,14 @@ class AccessControlProvider
             }
 
             if (!$authorized) {
-                $error = wp_sprintf(
-                    // translators: 1: elFInder Command
-                    __(
-                        'You are not authorized to run this command [ %s ] on file manager',
-                        'file-manager'
-                    ),
-                    $cmd
-                );
+                $action = $permissionProvider->commandLabel($cmd);
+                $error  = $action !== ''
+                    ? wp_sprintf(
+                        // translators: 1: human-readable action, e.g. "edit files"
+                        __("You don't have permission to %s here.", 'file-manager'),
+                        $action
+                    )
+                    : __("You don't have permission to do that here.", 'file-manager');
             }
         }
 
@@ -240,23 +240,17 @@ class AccessControlProvider
     {
         $hashes = [];
 
-        if (isset($cmdArgs['target']) && \is_string($cmdArgs['target'])) {
-            $hashes[] = $cmdArgs['target'];
-        }
-        if (isset($cmdArgs['dst']) && \is_string($cmdArgs['dst'])) {
-            $hashes[] = $cmdArgs['dst'];
-        }
-        if (isset($cmdArgs['targets']) && \is_array($cmdArgs['targets'])) {
-            foreach ($cmdArgs['targets'] as $target) {
-                if (\is_string($target)) {
-                    $hashes[] = $target;
-                }
+        foreach (['target', 'dst'] as $key) {
+            if (isset($cmdArgs[$key]) && \is_string($cmdArgs[$key])) {
+                $hashes[] = $cmdArgs[$key];
             }
         }
-        if (isset($cmdArgs['upload_path']) && \is_array($cmdArgs['upload_path'])) {
-            foreach ($cmdArgs['upload_path'] as $uploadPath) {
-                if (\is_string($uploadPath)) {
-                    $hashes[] = $uploadPath;
+        foreach (['targets', 'upload_path'] as $key) {
+            if (isset($cmdArgs[$key]) && \is_array($cmdArgs[$key])) {
+                foreach ($cmdArgs[$key] as $hash) {
+                    if (\is_string($hash)) {
+                        $hashes[] = $hash;
+                    }
                 }
             }
         }

--- a/backend/app/Providers/AccessControlProvider.php
+++ b/backend/app/Providers/AccessControlProvider.php
@@ -223,6 +223,51 @@ class AccessControlProvider
         }
     }
 
+    public function resolveInvolvedPaths(array $cmdArgs, $elfinder): array
+    {
+        $hashes = [];
+
+        if (isset($cmdArgs['target']) && \is_string($cmdArgs['target'])) {
+            $hashes[] = $cmdArgs['target'];
+        }
+        if (isset($cmdArgs['dst']) && \is_string($cmdArgs['dst'])) {
+            $hashes[] = $cmdArgs['dst'];
+        }
+        if (isset($cmdArgs['targets']) && \is_array($cmdArgs['targets'])) {
+            foreach ($cmdArgs['targets'] as $target) {
+                if (\is_string($target)) {
+                    $hashes[] = $target;
+                }
+            }
+        }
+
+        $paths = [];
+        foreach (array_unique($hashes) as $hash) {
+            $volume = $elfinder->getVolume($hash);
+            if (!\is_object($volume) || !method_exists($volume, 'getPath')) {
+                continue;
+            }
+            $path = $volume->getPath($hash);
+            if (\is_string($path) && $path !== '') {
+                $paths[] = $path;
+            }
+        }
+
+        return $paths;
+    }
+
+    public function isCommandAllowedForPaths($cmd, array $paths, PermissionsProvider $permissions)
+    {
+        foreach ($paths as $path) {
+            $enabled = $permissions->getEnabledCommandsForPath($path);
+            if (!\in_array($cmd, $enabled, true) && !\in_array('*', $enabled, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function isFileAllowedToOpen($args)
     {
         if (isset($args[1]) && $args[1] instanceof elFinder) {

--- a/backend/app/Providers/AccessControlProvider.php
+++ b/backend/app/Providers/AccessControlProvider.php
@@ -88,17 +88,30 @@ class AccessControlProvider
             $cmd = 'edit';
         }
 
-        if (
-            $this->isNotRequiredCommandForAllPermission($cmd, $permissionProvider)
-             && !$permissionProvider->currentUserCanRun($cmd)) {
-            $error = wp_sprintf(
-                // translators: 1: elFInder Command
-                __(
-                    'You are not authorized to run this command [ %s ] on file manager',
-                    'file-manager'
-                ),
-                $cmd
-            );
+        if ($this->isNotRequiredCommandForAllPermission($cmd, $permissionProvider)) {
+            $elfinder = isset($args[1])    && $args[1] instanceof elFinder ? $args[1] : null;
+            $paths    = $elfinder !== null && isset($args[0]) && \is_array($args[0])
+                ? $this->resolveInvolvedPaths($args[0], $elfinder)
+                : [];
+
+            if (!empty($paths)) {
+                // Path-aware check is authoritative when targets resolve.
+                $authorized = $this->isCommandAllowedForPaths($cmd, $paths, $permissionProvider);
+            } else {
+                // No resolvable target (early connector call / target-less command): coarse union.
+                $authorized = $permissionProvider->currentUserCanRun($cmd);
+            }
+
+            if (!$authorized) {
+                $error = wp_sprintf(
+                    // translators: 1: elFInder Command
+                    __(
+                        'You are not authorized to run this command [ %s ] on file manager',
+                        'file-manager'
+                    ),
+                    $cmd
+                );
+            }
         }
 
         if ($command == 'file' && $this->isFileAllowedToOpen($args)) {

--- a/backend/app/Providers/AccessControlProvider.php
+++ b/backend/app/Providers/AccessControlProvider.php
@@ -94,11 +94,11 @@ class AccessControlProvider
                 ? $this->resolveInvolvedPaths($args[0], $elfinder)
                 : [];
 
-            if (!empty($paths)) {
-                // Path-aware check is authoritative when targets resolve.
+            if (!empty($paths) && \in_array($cmd, $permissionProvider->allCommands(), true)) {
+                // Path-aware check is authoritative for managed commands when targets resolve.
                 $authorized = $this->isCommandAllowedForPaths($cmd, $paths, $permissionProvider);
             } else {
-                // No resolvable target (early connector call / target-less command): coarse union.
+                // Non-managed command or no resolvable target: coarse union (admin + capability filter).
                 $authorized = $permissionProvider->currentUserCanRun($cmd);
             }
 

--- a/backend/app/Providers/AccessControlProvider.php
+++ b/backend/app/Providers/AccessControlProvider.php
@@ -253,6 +253,13 @@ class AccessControlProvider
                 }
             }
         }
+        if (isset($cmdArgs['upload_path']) && \is_array($cmdArgs['upload_path'])) {
+            foreach ($cmdArgs['upload_path'] as $uploadPath) {
+                if (\is_string($uploadPath)) {
+                    $hashes[] = $uploadPath;
+                }
+            }
+        }
 
         $paths = [];
         foreach (array_unique($hashes) as $hash) {

--- a/backend/app/Providers/FileManager/FileRoot.php
+++ b/backend/app/Providers/FileManager/FileRoot.php
@@ -836,7 +836,10 @@ class FileRoot
 
     public function getOptions()
     {
-        $options['tmbPath']            = $this->getOption('_tmbPath');
+        // Thumbnails disabled: elFinder caches them under the web-served volume
+        // root, leaking downscaled copies past the permission gate. '' not null —
+        // null is isset()-false, so elFinder falls back to its '.tmb' default.
+        $options['tmbPath']            = '';
         $options['id']                 = $this->getOption('_id');
         $options['alias']              = $this->getOption('_alias');
         $options['driver']             = $this->getOption('_driver');

--- a/backend/app/Providers/FileManager/Options.php
+++ b/backend/app/Providers/FileManager/Options.php
@@ -163,6 +163,18 @@ class Options
     }
 
     /**
+     * Normalize bind keys by collapsing all whitespace runs to single spaces
+     *
+     * @param string $commandType
+     *
+     * @return string
+     */
+    public static function normalizeBindKey(string $commandType): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', $commandType));
+    }
+
+    /**
      * Sets bind for command actions
      *
      * @param string   $commandType
@@ -172,7 +184,7 @@ class Options
      */
     public function setBind($commandType, callable $callback)
     {
-        $this->_bind[$commandType][] = $callback;
+        $this->_bind[self::normalizeBindKey((string) $commandType)][] = $callback;
 
         return $this;
     }

--- a/backend/app/Providers/FileManager/Options.php
+++ b/backend/app/Providers/FileManager/Options.php
@@ -69,13 +69,6 @@ class Options
      */
     private $_commonTempPath;
 
-    /*
-     * Thumbnail path.
-     *
-     * Default value: file-manager upload directory + '/.tmb'
-     */
-    private $_tmbPath;
-
     /**
      * Connection flag files path that connection check of current request.
      *  A file is created every time an access is made to this location and it is deleted at the end of the request.
@@ -184,7 +177,7 @@ class Options
      */
     public function setBind($commandType, callable $callback)
     {
-        $this->_bind[self::normalizeBindKey((string) $commandType)][] = $callback;
+        $this->_bind[self::normalizeBindKey($commandType)][] = $callback;
 
         return $this;
     }
@@ -213,13 +206,6 @@ class Options
     public function setCommonTempPath($path)
     {
         $this->_commonTempPath = $path;
-
-        return $this;
-    }
-
-    public function setThumbPath($path)
-    {
-        $this->_tmbPath = $path;
 
         return $this;
     }
@@ -267,10 +253,6 @@ class Options
 
         if (isset($this->_commonTempPath)) {
             $options['commonTempPath'] = $this->_commonTempPath;
-        }
-
-        if (isset($this->_tmbPath)) {
-            $options['tmbPath'] = $this->_tmbPath;
         }
 
         if (isset($this->_connectionFlagsPath)) {

--- a/backend/app/Providers/MediaSynchronizer.php
+++ b/backend/app/Providers/MediaSynchronizer.php
@@ -21,7 +21,10 @@ class MediaSynchronizer
     {
         $targetPath = $volume->getPath($args['target']);
 
-        if (strpos($targetPath, $this->wpUploadBaseDirectory) !== false && Plugin::instance()->preferences()->isWpMediaSyncEnabled()) {
+        if (
+            PermissionsProvider::realpathWithin($targetPath, $this->wpUploadBaseDirectory) !== null
+            && Plugin::instance()->preferences()->isWpMediaSyncEnabled()
+        ) {
             $images = [];
             for ($file = 0; $file < \count($args['FILES']['upload']['name']); $file++) {
                 $images[] = [

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -504,14 +504,21 @@ class PermissionsProvider
         }
 
         $boundary = realpath($userPath);
-        $target   = realpath($absPath);
         if ($boundary === false) {
             return false;
         }
 
-        // If the target does not exist yet (e.g. mkdir destination is the parent),
-        // fall back to the raw path; the parent still normalizes its own realpath.
-        $target = $target === false ? $absPath : $target;
+        $target = realpath($absPath);
+        if ($target === false) {
+            // Target does not exist yet (e.g. a create destination). Canonicalize via the
+            // parent so a raw '..' cannot string-match the boundary; reject if the parent
+            // itself does not resolve.
+            $parent = realpath(\dirname($absPath));
+            if ($parent === false) {
+                return false;
+            }
+            $target = $parent . DIRECTORY_SEPARATOR . basename($absPath);
+        }
 
         return self::isSubPath($target, $boundary);
     }

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -549,7 +549,7 @@ class PermissionsProvider
             return false;
         }
 
-        $userPath = $this->permissionsForCurrentUser()['path'];
+        $userPath = $this->permissionsForCurrentUser()['path'] ?? null;
         if (!\is_string($userPath) || $userPath === '') {
             return false;
         }

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -511,6 +511,63 @@ class PermissionsProvider
         return $disabledCommand;
     }
 
+    public function isPathUnderUserPermission(string $absPath): bool
+    {
+        if (!is_user_logged_in() || !$this->isCurrentUserHasPermission()) {
+            return false;
+        }
+
+        $userPath = $this->permissionsForCurrentUser()['path'];
+        if (!\is_string($userPath) || $userPath === '') {
+            return false;
+        }
+
+        $boundary = realpath($userPath);
+        $target   = realpath($absPath);
+        if ($boundary === false) {
+            return false;
+        }
+
+        // If the target does not exist yet (e.g. mkdir destination is the parent),
+        // fall back to the raw path; the parent still normalizes its own realpath.
+        $target = $target === false ? $absPath : $target;
+
+        return self::isSubPath($target, $boundary);
+    }
+
+    public function getEnabledCommandsForPath(string $absPath): array
+    {
+        if (!is_user_logged_in()) {
+            return $this->getGuestPermissions()['commands'];
+        }
+
+        if ($this->isPathUnderUserPermission($absPath)) {
+            return $this->permissionsForCurrentUser()['commands'];
+        }
+
+        return $this->permissionsForCurrentRole()['commands'];
+    }
+
+    public function getEnabledCommandsUnion(): array
+    {
+        return array_values(array_unique(array_merge(
+            $this->permissionsForCurrentUser()['commands'],
+            $this->permissionsForCurrentRole()['commands']
+        )));
+    }
+
+    public function getDisabledCommandFor(array $enabledCommands): array
+    {
+        $disabled = [];
+        foreach ($this->allCommands() as $command) {
+            if (!\in_array($command, $enabledCommands, true)) {
+                $disabled[] = $command;
+            }
+        }
+
+        return $disabled;
+    }
+
     public function updatePermissionSetting($permissions)
     {
         return Config::updateOption('permissions', $permissions, 'yes');

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -16,6 +16,23 @@ use WP_User;
 \defined('ABSPATH') || exit();
 class PermissionsProvider
 {
+    private const ALL_COMMANDS = [
+        'download', // file, zipdl
+        'cut',// only for frontend. send cmd as paste
+        'copy',// only for frontend. send cmd as paste
+        'edit', // put
+        'rm', // rm
+        'upload',// upload
+        'duplicate', // duplicate
+        'paste', // paste
+        'mkfile',// mkfile
+        'mkdir',// mkdir
+        'rename', // rename
+        'archive', // archive
+        'extract',// extract
+        'emailto', // client-only: open mailto link for selected file
+    ];
+
     public $permissions;
 
     public $users;
@@ -98,23 +115,6 @@ class PermissionsProvider
 
         return isset($users[$id]) ? $users[$id]->display_name : 'guest';
     }
-
-    private const ALL_COMMANDS = [
-        'download', // file, zipdl
-        'cut',// only for frontend. send cmd as paste
-        'copy',// only for frontend. send cmd as paste
-        'edit', // put
-        'rm', // rm
-        'upload',// upload
-        'duplicate', // duplicate
-        'paste', // paste
-        'mkfile',// mkfile
-        'mkdir',// mkdir
-        'rename', // rename
-        'archive', // archive
-        'extract',// extract
-        'emailto', // client-only: open mailto link for selected file
-    ];
 
     public function allCommands()
     {

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -306,20 +306,10 @@ class PermissionsProvider
 
     public static function isSubPath(string $path, string $boundary): bool
     {
-        if ($boundary === '') {
-            return false;
-        }
+        $path     = rtrim(str_replace('\\', '/', $path), '/');
+        $boundary = rtrim(str_replace('\\', '/', $boundary), '/');
 
-        $normalize = static function (string $value): string {
-            $value = str_replace('\\', '/', $value);
-
-            return rtrim($value, '/');
-        };
-
-        $path     = $normalize($path);
-        $boundary = $normalize($boundary);
-
-        if ($boundary === '') { // boundary was only separators
+        if ($boundary === '') { // empty or separator-only boundary matches nothing
             return false;
         }
 
@@ -499,16 +489,7 @@ class PermissionsProvider
             return [];
         }
 
-        $enabledCommands = $this->getEnabledCommand();
-
-        $disabledCommand = [];
-        foreach ($this->allCommands() as $command) {
-            if (!\in_array($command, $enabledCommands)) {
-                $disabledCommand[] = $command;
-            }
-        }
-
-        return $disabledCommand;
+        return $this->getDisabledCommandFor($this->getEnabledCommand());
     }
 
     public function isPathUnderUserPermission(string $absPath): bool

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -99,24 +99,57 @@ class PermissionsProvider
         return isset($users[$id]) ? $users[$id]->display_name : 'guest';
     }
 
+    private const ALL_COMMANDS = [
+        'download', // file, zipdl
+        'cut',// only for frontend. send cmd as paste
+        'copy',// only for frontend. send cmd as paste
+        'edit', // put
+        'rm', // rm
+        'upload',// upload
+        'duplicate', // duplicate
+        'paste', // paste
+        'mkfile',// mkfile
+        'mkdir',// mkdir
+        'rename', // rename
+        'archive', // archive
+        'extract',// extract
+        'emailto', // client-only: open mailto link for selected file
+    ];
+
     public function allCommands()
     {
-        return [
-            'download', // file, zipdl
-            'cut',// only for frontend. send cmd as paste
-            'copy',// only for frontend. send cmd as paste
-            'edit', // put
-            'rm', // rm
-            'upload',// upload
-            'duplicate', // duplicate
-            'paste', // paste
-            'mkfile',// mkfile
-            'mkdir',// mkdir
-            'rename', // rename
-            'archive', // archive
-            'extract',// extract
-            'emailto', // client-only: open mailto link for selected file
+        return self::ALL_COMMANDS;
+    }
+
+    /**
+     * Human-readable action phrase for a command, for user-facing errors.
+     * Kept here so command names and their labels share one owner; labels can't
+     * live on the ALL_COMMANDS const because __() can't run in a const context.
+     *
+     * @param string $cmd normalized elFinder command
+     *
+     * @return string empty when the command has no friendly label
+     */
+    public function commandLabel($cmd)
+    {
+        $labels = [
+            'download'  => __('download files', 'file-manager'),
+            'cut'       => __('move items', 'file-manager'),
+            'copy'      => __('copy items', 'file-manager'),
+            'edit'      => __('edit files', 'file-manager'),
+            'rm'        => __('delete items', 'file-manager'),
+            'upload'    => __('upload files', 'file-manager'),
+            'duplicate' => __('duplicate items', 'file-manager'),
+            'paste'     => __('paste items', 'file-manager'),
+            'mkfile'    => __('create files', 'file-manager'),
+            'mkdir'     => __('create folders', 'file-manager'),
+            'rename'    => __('rename items', 'file-manager'),
+            'archive'   => __('create archives', 'file-manager'),
+            'extract'   => __('extract archives', 'file-manager'),
+            'emailto'   => __('email files', 'file-manager'),
         ];
+
+        return $labels[$cmd] ?? '';
     }
 
     public function defaultPermissions()
@@ -314,6 +347,24 @@ class PermissionsProvider
         }
 
         return $path === $boundary || strpos($path, $boundary . '/') === 0;
+    }
+
+    /**
+     * Canonicalize $path and return it only when it resolves inside $boundary.
+     *
+     * @return string|null resolved target path, or null when either side fails to
+     *                     resolve or the target escapes the boundary
+     */
+    public static function realpathWithin(string $path, string $boundary): ?string
+    {
+        $boundaryReal = realpath($boundary);
+        $target       = realpath($path);
+
+        if ($boundaryReal === false || $target === false || !self::isSubPath($target, $boundaryReal)) {
+            return null;
+        }
+
+        return $target;
     }
 
     public function getGuestPermissions()
@@ -554,6 +605,30 @@ class PermissionsProvider
         }
 
         return $disabled;
+    }
+
+    /**
+     * Disabled-command hint for the Public volume. Least-restrictive (user ∪ role) so a
+     * nested per-user folder never hides legitimate commands; the runtime gate enforces
+     * the real per-path policy.
+     */
+    public function getPublicVolumeDisabledCommands(): array
+    {
+        return $this->getDisabledCommandFor($this->getEnabledCommandsUnion());
+    }
+
+    public function getRoleVolumeDisabledCommands(): array
+    {
+        return $this->getDisabledCommandFor($this->permissionsForCurrentRole()['commands']);
+    }
+
+    public function getUserVolumeDisabledCommands(): array
+    {
+        $commands = $this->isCurrentUserHasPermission()
+            ? $this->permissionsForCurrentUser()['commands']
+            : $this->permissionsForCurrentRole()['commands'];
+
+        return $this->getDisabledCommandFor($commands);
     }
 
     public function updatePermissionSetting($permissions)

--- a/backend/app/Providers/PermissionsProvider.php
+++ b/backend/app/Providers/PermissionsProvider.php
@@ -304,6 +304,28 @@ class PermissionsProvider
         return $settings;
     }
 
+    public static function isSubPath(string $path, string $boundary): bool
+    {
+        if ($boundary === '') {
+            return false;
+        }
+
+        $normalize = static function (string $value): string {
+            $value = str_replace('\\', '/', $value);
+
+            return rtrim($value, '/');
+        };
+
+        $path     = $normalize($path);
+        $boundary = $normalize($boundary);
+
+        if ($boundary === '') { // boundary was only separators
+            return false;
+        }
+
+        return $path === $boundary || strpos($path, $boundary . '/') === 0;
+    }
+
     public function getGuestPermissions()
     {
         $settings = [

--- a/backend/app/Providers/PhpSyntaxChecker.php
+++ b/backend/app/Providers/PhpSyntaxChecker.php
@@ -26,7 +26,7 @@ class PhpSyntaxChecker
     {
         $previousContent = file_get_contents($realFile);
 
-        // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.WP.AlternativeFunctions.file_system_operations_fwrite, WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+        // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.WP.AlternativeFunctions.file_system_operations_fwrite, WordPress.WP.AlternativeFunctions.file_system_operations_fclose, WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
         if (!is_writable($realFile)) {
             return new WP_Error('file_not_writable');
         }

--- a/backend/app/Views/Admin.php
+++ b/backend/app/Views/Admin.php
@@ -130,9 +130,9 @@ class Admin
         wp_enqueue_script(Config::SLUG . 'elfinder-editor-script');
         wp_enqueue_script(Config::SLUG . 'elfinder-lang', $preferences->getLangUrl(), [Config::SLUG . 'elfinder-script']);
 
-        if (Config::isDev()) {
-            $port   = file_get_contents(Config::get('BASEDIR') . '/port');
-            $devUrl = 'http://localhost:' . $port;
+        $devPort = Config::devPort();
+        if ($devPort > 0) {
+            $devUrl = 'http://localhost:' . $devPort;
             wp_enqueue_script(
                 Config::SLUG . '-MODULE-vite-client-helper',
                 $devUrl . '/config/devHotModule.js',

--- a/file-manager.php
+++ b/file-manager.php
@@ -8,7 +8,7 @@ if (! \defined('ABSPATH')) {
  * Plugin URI: https://bitapps.pro/bit-file-manager
  * Author:     File Manager by Bit Form Team
  * Author URI:  https://bitapps.pro
- * Version: 6.8.9
+ * Version: 6.9
  * Requires at least: 5.0
  * Requires PHP: 7.4
  * Text domain: file-manager

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router-dom'
 import { StyleProvider } from '@ant-design/cssinjs'
 import { $appConfig } from '@common/globalStates'
 import { removeUnwantedCSS, setAppBgFromAdminBg } from '@common/helpers/globalHelpers'
+import useSyncAdminMenu from '@common/hooks/useSyncAdminMenu'
 import { darkThemeComponentToken, darkThemeToken } from '@config/themes/theme.dark'
 import { lightThemeComponentToken, lightThemeToken } from '@config/themes/theme.light'
 import loadable from '@loadable/component'
@@ -25,6 +26,8 @@ export default function AppRoutes() {
   const themeTokens = isDarkTheme ? darkThemeToken : lightThemeToken
   const componentTokens = isDarkTheme ? darkThemeComponentToken : lightThemeComponentToken
   const themeAlgorithm = isDarkTheme ? darkAlgorithm : defaultAlgorithm
+
+  useSyncAdminMenu()
 
   useEffect(() => {
     removeUnwantedCSS()

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -5,6 +5,7 @@ import { StyleProvider } from '@ant-design/cssinjs'
 import { $appConfig } from '@common/globalStates'
 import { removeUnwantedCSS, setAppBgFromAdminBg } from '@common/helpers/globalHelpers'
 import useSyncAdminMenu from '@common/hooks/useSyncAdminMenu'
+import { setNotificationInstance } from '@common/notificationInstance'
 import { darkThemeComponentToken, darkThemeToken } from '@config/themes/theme.dark'
 import { lightThemeComponentToken, lightThemeToken } from '@config/themes/theme.light'
 import loadable from '@loadable/component'
@@ -21,6 +22,10 @@ const SystemInformation = loadable(() => import('@pages/SystemInformation'), { f
 
 const { defaultAlgorithm, darkAlgorithm } = theme
 
+const NOTIFICATION_PLACEMENT = 'bottomRight'
+// Configure the static notification instance (used by callers outside the tree) once.
+notification.config({ placement: NOTIFICATION_PLACEMENT })
+
 export default function AppRoutes() {
   const { isDarkTheme } = useAtomValue($appConfig)
   const themeTokens = isDarkTheme ? darkThemeToken : lightThemeToken
@@ -34,8 +39,17 @@ export default function AppRoutes() {
     setAppBgFromAdminBg()
   }, [])
 
-  const [, contextHolder] = notification.useNotification()
-  notification.config({ placement: 'bottomRight', maxCount: 3 })
+  // No maxCount: it force-destroys the oldest notice, which silently evicts a
+  // persistent error the moment transient toasts arrive. `stack` keeps the pile
+  // tidy without dropping anything.
+  const [notificationApi, contextHolder] = notification.useNotification({
+    placement: NOTIFICATION_PLACEMENT
+  })
+
+  useEffect(() => {
+    setNotificationInstance(notificationApi)
+    return () => setNotificationInstance(null)
+  }, [notificationApi])
   return (
     <ConfigProvider
       theme={{

--- a/frontend/src/common/hooks/useSyncAdminMenu.tsx
+++ b/frontend/src/common/hooks/useSyncAdminMenu.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import config from '@config/config'
+
+const CURRENT_CLASS = 'current'
+const DEFAULT_HASH = '#/home'
+
+/**
+ * Mirror the active SPA route onto the WordPress admin submenu highlight.
+ * WordPress resolves the current menu server-side from the `page` query var
+ * alone and never sees the client-side hash route, so it can't keep the right
+ * submenu item active on its own — we sync the DOM on every navigation.
+ */
+export default function useSyncAdminMenu() {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    const slug = config.PLUGIN_SLUG
+    if (!slug) return
+
+    const routeAnchor = document.querySelector<HTMLAnchorElement>(`#adminmenu a[href*="page=${slug}#/"]`)
+    const menuItem = routeAnchor?.closest('#adminmenu > li')
+    if (!menuItem) return
+
+    const activeHash = pathname === '/' ? DEFAULT_HASH : `#${pathname}`
+    const anchors = Array.from(menuItem.querySelectorAll<HTMLAnchorElement>('.wp-submenu a'))
+
+    anchors.forEach(anchor => {
+      anchor.classList.remove(CURRENT_CLASS)
+      anchor.removeAttribute('aria-current')
+      anchor.closest('li')?.classList.remove(CURRENT_CLASS)
+    })
+
+    const matched = anchors.find(anchor => anchor.hash === activeHash)
+    if (matched) {
+      matched.classList.add(CURRENT_CLASS)
+      matched.setAttribute('aria-current', 'page')
+      matched.closest('li')?.classList.add(CURRENT_CLASS)
+    }
+  }, [pathname])
+}

--- a/frontend/src/common/hooks/useSyncAdminMenu.tsx
+++ b/frontend/src/common/hooks/useSyncAdminMenu.tsx
@@ -32,7 +32,7 @@ export default function useSyncAdminMenu() {
       anchor.closest('li')?.classList.remove(CURRENT_CLASS)
     })
 
-    const matched = anchors.find(anchor => anchor.hash === activeHash)
+    const matched = anchors.find(anchor => (anchor.hash || '#/home') === activeHash)
     if (matched) {
       matched.classList.add(CURRENT_CLASS)
       matched.setAttribute('aria-current', 'page')

--- a/frontend/src/common/notificationInstance.ts
+++ b/frontend/src/common/notificationInstance.ts
@@ -1,0 +1,16 @@
+import { notification } from 'antd'
+
+export type NotificationInstance = ReturnType<typeof notification.useNotification>[0]
+
+let instance: NotificationInstance | null = null
+
+export const setNotificationInstance = (api: NotificationInstance | null): void => {
+  instance = api
+}
+
+// The static `notification` instance renders outside ConfigProvider, so it
+// ignores the app's high `zIndexPopupBase` and ends up hidden behind the WP
+// admin shell. Callers reachable from React should prefer the context-aware
+// instance AppRoutes publishes here; the static fallback only covers the brief
+// window before it is set.
+export const resolveNotification = (): NotificationInstance => instance ?? notification

--- a/frontend/src/config/test.setup.ts
+++ b/frontend/src/config/test.setup.ts
@@ -1,0 +1,1 @@
+// Test environment setup

--- a/frontend/src/config/themes/common.ts
+++ b/frontend/src/config/themes/common.ts
@@ -10,7 +10,10 @@ const commonThemeToken: Partial<AliasToken> = {
   borderRadiusXS: 4,
   colorPrimary: '#006afe',
   colorSuccess: '#00ff7d',
-  colorWarning: '#ffc041'
+  colorWarning: '#ffc041',
+  // Lift all antd popups above the WP admin shell: #wpbody-content is a z-index:9999
+  // sticky stacking context that otherwise buries the default z-index:1000 popups.
+  zIndexPopupBase: 10000
 }
 
 export default commonThemeToken

--- a/frontend/src/lib/elfinder/notificationBridge.test.ts
+++ b/frontend/src/lib/elfinder/notificationBridge.test.ts
@@ -1,0 +1,107 @@
+import { resolveNotification } from '@common/notificationInstance'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import bridgeElFinderNotifications from './notificationBridge'
+import { type FinderWithDialog } from './types'
+
+vi.mock('@common/notificationInstance', () => {
+  const api = { success: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn() }
+  return { resolveNotification: () => api }
+})
+
+const notification = resolveNotification() as unknown as {
+  success: ReturnType<typeof vi.fn>
+  info: ReturnType<typeof vi.fn>
+  warning: ReturnType<typeof vi.fn>
+  error: ReturnType<typeof vi.fn>
+}
+
+type ErrorHandler = (event: { data?: { error?: unknown; opts?: unknown } }) => unknown
+
+function setup() {
+  const nativeToast = vi.fn()
+  let errorHandler: ErrorHandler = () => undefined
+  const finder = {
+    toast: nativeToast,
+    i18n: (message: unknown) => String(message),
+    bind: (events: string, handler: ErrorHandler, priorityFirst?: boolean) => {
+      if (events === 'error' && priorityFirst) {
+        errorHandler = handler
+      }
+      return finder
+    }
+  } as unknown as FinderWithDialog
+
+  bridgeElFinderNotifications(finder)
+  return { finder, nativeToast, getErrorHandler: () => errorHandler }
+}
+
+describe('bridgeElFinderNotifications', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('routes a plain toast to the matching antd notification', () => {
+    const { finder } = setup()
+    finder.toast({ mode: 'error', msg: 'boom' })
+    expect(notification.error).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }))
+  })
+
+  it("defaults a mode-less toast to elFinder's success mode", () => {
+    const { finder } = setup()
+    finder.toast({ msg: 'done' })
+    expect(notification.success).toHaveBeenCalledWith(expect.objectContaining({ message: 'done' }))
+  })
+
+  it('maps timeOut (ms) to antd duration (seconds)', () => {
+    const { finder } = setup()
+    finder.toast({ mode: 'info', msg: 'hi', timeOut: 5000 })
+    expect(notification.info).toHaveBeenCalledWith(expect.objectContaining({ duration: 5 }))
+  })
+
+  it('keeps interactive/sticky toasts native', () => {
+    const { finder, nativeToast } = setup()
+    finder.toast({ mode: 'info', msg: 'wait', button: { text: 'Undo' } })
+    finder.toast({ mode: 'info', msg: 'sticky', timeOut: 0 })
+    expect(nativeToast).toHaveBeenCalledTimes(2)
+    expect(notification.info).not.toHaveBeenCalled()
+  })
+
+  it('flattens toast HTML and resolves %token% placeholders without re-i18n', () => {
+    const { finder } = setup()
+    finder.toast({ mode: 'warning', msg: 'Max <span class="v">5</span> in %cwd%' })
+    expect(notification.warning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Max 5 in cwd' })
+    )
+  })
+
+  it('routes an error event to a persistent antd notification and suppresses the native dialog', () => {
+    const { getErrorHandler } = setup()
+    const result = getErrorHandler()({ data: { error: 'errAccess' } })
+    expect(notification.error).toHaveBeenCalledWith({ message: 'errAccess', duration: 0 })
+    expect(result).toBe(false)
+  })
+
+  it('flattens elFinder HTML (entities + tags) to plain text', () => {
+    const { getErrorHandler } = setup()
+    getErrorHandler()({
+      data: { error: 'You don&#039;t have permission <span class="v">test.php</span>' }
+    })
+    expect(notification.error).toHaveBeenCalledWith({
+      message: "You don't have permission test.php",
+      duration: 0
+    })
+  })
+
+  it('lets must-acknowledge (modal) errors fall through to the native dialog', () => {
+    const { getErrorHandler } = setup()
+    const result = getErrorHandler()({ data: { error: 'errNetMount', opts: { modal: true } } })
+    expect(notification.error).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('ignores empty error events', () => {
+    const { getErrorHandler } = setup()
+    const result = getErrorHandler()({ data: {} })
+    expect(notification.error).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/elfinder/notificationBridge.ts
+++ b/frontend/src/lib/elfinder/notificationBridge.ts
@@ -1,0 +1,89 @@
+import { resolveNotification } from '@common/notificationInstance'
+
+import {
+  type ElFinderEvent,
+  type ElFinderToastMode,
+  type ElFinderToastOptions,
+  type FinderWithDialog
+} from './types'
+
+// elFinder's toast modes are already antd notification's method names; the set
+// only guards an unexpected runtime mode down to the 'success' default.
+const TOAST_MODES = new Set<ElFinderToastMode>(['success', 'info', 'warning', 'error'])
+
+// Toasts elFinder keeps a live handle on (progress nodes, action buttons,
+// lifecycle callbacks, sticky) must stay native — antd notification can't be
+// updated, closed, or interacted with by the original caller once shown.
+const isManagedToast = (options: ElFinderToastOptions): boolean =>
+  options.extNode != null ||
+  options.button != null ||
+  options.onShown != null ||
+  options.onHidden != null ||
+  options.timeOut === 0
+
+// elFinder's show/hide values are fade timings, not display time — only
+// `timeOut` (ms) maps to antd's `duration` (seconds).
+const toDuration = (timeOut: unknown): number | undefined =>
+  typeof timeOut === 'number' && timeOut > 0 ? timeOut / 1000 : undefined
+
+// elFinder's i18n output is HTML (escaped entities + <span> markup around
+// interpolated values) built for innerHTML; antd renders message as text, so
+// flatten it to decoded plain text. DOMParser neither executes scripts nor
+// loads resources, so this stays XSS-safe.
+const toPlainText = (html: string): string =>
+  new DOMParser().parseFromString(html, 'text/html').body.textContent ?? ''
+
+/**
+ * Route elFinder's transient toasts and error events into antd notification so
+ * they match the rest of the plugin UI. Interactive and must-acknowledge
+ * dialogs stay native.
+ */
+export default function bridgeElFinderNotifications(finder: FinderWithDialog): void {
+  const nativeToast = finder.toast.bind(finder)
+
+  // Toast callers pass an already-i18n'd display string; the native widget only
+  // resolves %token% placeholders and renders it as HTML. Mirror that instead of
+  // re-running i18n (which would double-escape), then flatten to plain text.
+  const renderToastMsg = (msg: string): string =>
+    toPlainText(msg.replace(/%([a-zA-Z0-9]+)%/g, (_, token) => finder.i18n(token)))
+
+  finder.toast = (options: ElFinderToastOptions = {}) => {
+    if (isManagedToast(options)) {
+      return nativeToast(options)
+    }
+    // elFinder's own toast default mode is 'success'.
+    const mode = options.mode as ElFinderToastMode
+    const type: ElFinderToastMode = TOAST_MODES.has(mode) ? mode : 'success'
+    resolveNotification()[type]({
+      message: renderToastMsg(options.msg ?? ''),
+      duration: toDuration(options.timeOut)
+    })
+    return undefined
+  }
+
+  // Returning false stops elFinder's trigger loop before its default handler
+  // (elfinder.full.js:1101), suppressing the native error modal. priorityFirst
+  // keeps this ahead of that handler, so the bridge must remain the terminal
+  // 'error' listener — anything bound later via fm.error() would be skipped.
+  finder.bind(
+    'error',
+    event => {
+      const data = (event as ElFinderEvent)?.data
+      const error = data?.error
+      if (error == null) {
+        return undefined
+      }
+      // Errors flagged modal or carrying custom buttons must block until
+      // acknowledged — leave those to the native dialog.
+      const opts = data?.opts as { modal?: boolean; buttons?: unknown } | undefined
+      if (opts?.modal || opts?.buttons != null) {
+        return undefined
+      }
+      // duration 0 keeps the notice until dismissed, matching the native
+      // error dialog it replaces.
+      resolveNotification().error({ message: toPlainText(finder.i18n(error)), duration: 0 })
+      return false
+    },
+    true
+  )
+}

--- a/frontend/src/lib/elfinder/types.ts
+++ b/frontend/src/lib/elfinder/types.ts
@@ -19,7 +19,25 @@ export type ElFinderConstructor = {
   prototype: { commands: Record<string, () => void> }
 }
 
-export type FinderWithDialog = FinderInstance & {
+export type ElFinderToastMode = 'success' | 'info' | 'warning' | 'error'
+
+export interface ElFinderToastOptions {
+  mode?: ElFinderToastMode
+  msg?: string
+  hideDuration?: number
+  timeOut?: number
+  extNode?: unknown
+  button?: unknown
+  onShown?: unknown
+  onHidden?: unknown
+  [key: string]: unknown
+}
+
+export interface ElFinderEvent {
+  data?: { error?: unknown; opts?: unknown; [key: string]: unknown }
+}
+
+export type FinderWithDialog = Omit<FinderInstance, 'toast'> & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dialog: (content: unknown, options?: unknown) => any
   toFront: (target: unknown) => void
@@ -27,7 +45,13 @@ export type FinderWithDialog = FinderInstance & {
   changeTheme: (theme: string) => FinderWithDialog
   storage: (key: string, value?: unknown) => FinderWithDialog
   resize: (width: number | string, height: number | string) => void
-  bind: (events: string, handler: (...args: unknown[]) => void) => FinderWithDialog
+  i18n: (message: unknown) => string
+  toast: (options: ElFinderToastOptions) => unknown
+  bind: (
+    events: string,
+    handler: (...args: unknown[]) => unknown,
+    priorityFirst?: boolean
+  ) => FinderWithDialog
   dblclick?: (data: { file?: string }) => unknown
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   file: (hash: string) => any

--- a/frontend/src/pages/Layout/ui/Navigation/TopNavigation/TopNavigation.tsx
+++ b/frontend/src/pages/Layout/ui/Navigation/TopNavigation/TopNavigation.tsx
@@ -1,11 +1,12 @@
 import { $appConfig } from '@common/globalStates'
 import $finder from '@common/globalStates/$finder'
 import { __ } from '@common/helpers/i18nwrap'
+import { resolveNotification } from '@common/notificationInstance'
 import config from '@config/config'
 import AntIconWrapper from '@icons/AntIconWrapper'
 import LogoIcn from '@icons/LogoIcn'
 import LogoText from '@icons/LogoText'
-import { Button, Layout, Select, Space, Typography, notification, theme } from 'antd'
+import { Button, Layout, Select, Space, Typography, theme } from 'antd'
 import { useAtomValue } from 'jotai'
 
 import cls from './TopNavigation.module.css'
@@ -41,9 +42,9 @@ export default function TopNavigation() {
           window.location.reload()
         }
       } else if (response?.message) {
-        notification.error({ message: response.message })
+        resolveNotification().error({ message: response.message })
       } else {
-        response?.data?.theme?.map(error => notification.error({ message: error }))
+        response?.data?.theme?.map(error => resolveNotification().error({ message: error }))
       }
     })
   }
@@ -56,7 +57,7 @@ export default function TopNavigation() {
         // @ts-expect-error
         jQuery(`#${finder.id}`).elfinder('reload')
       } else {
-        notification.error({ message: response?.message ?? __('Failed to update language') })
+        resolveNotification().error({ message: response?.message ?? __('Failed to update language') })
       }
     })
   }

--- a/frontend/src/pages/Logs/ui/Logs.tsx
+++ b/frontend/src/pages/Logs/ui/Logs.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import { __ } from '@common/helpers/i18nwrap'
+import { resolveNotification } from '@common/notificationInstance'
 import useDeleteLog from '@pages/Logs/data/useDeleteLog'
 import {
   type LogQueryType,
@@ -8,7 +9,7 @@ import {
   type LoggedFileDetailsType
 } from '@pages/Logs/data/useFetchLogs'
 import useFetchLogs from '@pages/Logs/data/useFetchLogs'
-import { Button, Flex, type TableColumnsType, type TableProps, Typography, notification } from 'antd'
+import { Button, Flex, type TableColumnsType, type TableProps, Typography } from 'antd'
 import { Col, Row, Space, Table } from 'antd'
 
 type TableRowSelection<T extends object = object> = TableProps<T>['rowSelection']
@@ -66,9 +67,9 @@ export default function Logs() {
       if (res.code === 'SUCCESS') {
         setSelectedRowKeys([])
         refetch()
-        notification.success({ message: res?.message || 'Log deleted successfully' })
+        resolveNotification().success({ message: res?.message || 'Log deleted successfully' })
       } else {
-        notification.error({ message: res?.message || 'Failed to delete logs' })
+        resolveNotification().error({ message: res?.message || 'Failed to delete logs' })
       }
     })
   }

--- a/frontend/src/pages/Permissions/ui/AddUserPermissionModal.test.tsx
+++ b/frontend/src/pages/Permissions/ui/AddUserPermissionModal.test.tsx
@@ -22,6 +22,10 @@ describe('AddUserPermissionModal', () => {
 
   it('shows the file-manager-only subtitle when open', () => {
     render(<AddUserPermissionModal isModalOpen setIsModalOpen={vi.fn()} commands={['download']} />)
-    expect(screen.getByText('Only affects actions inside File Manager')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Controls what this user can do inside Bit File Manager only. Files reachable through the server (FTP, SSH, or other tools) are not affected.'
+      )
+    ).toBeTruthy()
   })
 })

--- a/frontend/src/pages/Permissions/ui/AddUserPermissionModal.test.tsx
+++ b/frontend/src/pages/Permissions/ui/AddUserPermissionModal.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import AddUserPermissionModal from './AddUserPermissionModal'
+
+// Data hooks hit the network/WP globals; stub them so the modal renders in isolation.
+vi.mock('@pages/Permissions/data/useFetchPermissionsSettings', () => ({
+  default: () => ({ refetch: vi.fn() })
+}))
+vi.mock('@pages/Permissions/data/useFetchUserByUsername', () => ({
+  default: () => ({ users: [], fetchNextPage: vi.fn(), isFetching: false, isFetchingNextPage: false })
+}))
+vi.mock('@pages/Permissions/data/useUpdateUserPermission', () => ({
+  default: () => ({ isUserPermissionUpdating: false, updateUserPermission: vi.fn() })
+}))
+
+describe('AddUserPermissionModal', () => {
+  afterEach(cleanup)
+
+  it('shows the file-manager-only subtitle when open', () => {
+    render(<AddUserPermissionModal isModalOpen setIsModalOpen={vi.fn()} commands={['download']} />)
+    expect(screen.getByText('Only affects actions inside File Manager')).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/Permissions/ui/AddUserPermissionModal.tsx
+++ b/frontend/src/pages/Permissions/ui/AddUserPermissionModal.tsx
@@ -6,7 +6,8 @@ import { type User, type UserPermissionType } from '@pages/Permissions/Permissio
 import useFetchPermissionsSettings from '@pages/Permissions/data/useFetchPermissionsSettings'
 import useFetchUserByUsername from '@pages/Permissions/data/useFetchUserByUsername'
 import useUpdateUserPermission from '@pages/Permissions/data/useUpdateUserPermission'
-import { Button, Card, Form, Input, Modal, Select, Space, Spin, notification } from 'antd'
+import { QuestionCircleOutlined } from '@ant-design/icons'
+import { Button, Card, Form, Input, Modal, Select, Space, Spin, Tooltip, Typography, notification } from 'antd'
 
 function AddUserPermissionModal({
   isModalOpen,
@@ -83,6 +84,7 @@ function AddUserPermissionModal({
       title="Set Permission for selected user"
     >
       <Space direction="vertical" style={{ display: 'flex' }} className="px-2">
+        <Typography.Text type="secondary">{__('Only affects actions inside File Manager')}</Typography.Text>
         <Select
           showSearch
           style={{ width: '100%' }}
@@ -112,7 +114,17 @@ function AddUserPermissionModal({
                 <Form.Item name="path" label={__('Path')}>
                   <Input placeholder="Root Folder Path" />
                 </Form.Item>
-                <Form.Item name="commands" label={__('Enabled Commands')}>
+                <Form.Item
+                  name="commands"
+                  label={
+                    <Space size={4}>
+                      {__('Enabled Commands')}
+                      <Tooltip title={__('These commands control what the user can do inside Bit File Manager only. They don\'t grant or change WordPress capabilities or the user\'s role.')}>
+                        <QuestionCircleOutlined />
+                      </Tooltip>
+                    </Space>
+                  }
+                >
                   <Select mode="multiple">
                     {commands?.map(command => (
                       <Select.Option key={command} value={command}>

--- a/frontend/src/pages/Permissions/ui/AddUserPermissionModal.tsx
+++ b/frontend/src/pages/Permissions/ui/AddUserPermissionModal.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react'
 
 import { __ } from '@common/helpers/i18nwrap'
 import useDebounce from '@common/hooks/useDebounce'
+import { resolveNotification } from '@common/notificationInstance'
 import { type User, type UserPermissionType } from '@pages/Permissions/PermissionsSettingsTypes'
 import useFetchPermissionsSettings from '@pages/Permissions/data/useFetchPermissionsSettings'
 import useFetchUserByUsername from '@pages/Permissions/data/useFetchUserByUsername'
 import useUpdateUserPermission from '@pages/Permissions/data/useUpdateUserPermission'
-import { Button, Card, Form, Input, Modal, Select, Space, Spin, Typography, notification } from 'antd'
+import { Alert, Button, Card, Form, Input, Modal, Select, Space, Spin } from 'antd'
 
 function AddUserPermissionModal({
   isModalOpen,
@@ -51,7 +52,7 @@ function AddUserPermissionModal({
   const handleSubmit = (changedValues: UserPermissionType) => {
     updateUserPermission(changedValues).then(response => {
       if (response.code === 'SUCCESS') {
-        notification.success({ message: response?.message ?? __('User permission deleted') })
+        resolveNotification().success({ message: response?.message ?? __('User permission deleted') })
         refetch()
         const updatedFields = form.getFieldsError().map(field => {
           if (field.errors) {
@@ -67,7 +68,7 @@ function AddUserPermissionModal({
             name: field.split('.'),
             errors: response.data[field] as string[]
           })
-          notification.error({ message: response?.message ?? __('Failed to save permission') })
+          resolveNotification().error({ message: response?.message ?? __('Failed to save permission') })
         })
         form.setFields(fieldErrors)
       }
@@ -83,7 +84,14 @@ function AddUserPermissionModal({
       title="Set Permission for selected user"
     >
       <Space direction="vertical" style={{ display: 'flex' }} className="px-2">
-        <Typography.Text type="secondary">{__('Only affects actions inside File Manager')}</Typography.Text>
+        <Alert
+          type="info"
+          showIcon
+          title={__('Scope of these permissions')}
+          description={__(
+            'Controls what this user can do inside Bit File Manager only. Files reachable through the server (FTP, SSH, or other tools) are not affected.'
+          )}
+        />
         <Select
           showSearch
           style={{ width: '100%' }}

--- a/frontend/src/pages/Permissions/ui/AddUserPermissionModal.tsx
+++ b/frontend/src/pages/Permissions/ui/AddUserPermissionModal.tsx
@@ -6,8 +6,7 @@ import { type User, type UserPermissionType } from '@pages/Permissions/Permissio
 import useFetchPermissionsSettings from '@pages/Permissions/data/useFetchPermissionsSettings'
 import useFetchUserByUsername from '@pages/Permissions/data/useFetchUserByUsername'
 import useUpdateUserPermission from '@pages/Permissions/data/useUpdateUserPermission'
-import { QuestionCircleOutlined } from '@ant-design/icons'
-import { Button, Card, Form, Input, Modal, Select, Space, Spin, Tooltip, Typography, notification } from 'antd'
+import { Button, Card, Form, Input, Modal, Select, Space, Spin, Typography, notification } from 'antd'
 
 function AddUserPermissionModal({
   isModalOpen,
@@ -116,14 +115,10 @@ function AddUserPermissionModal({
                 </Form.Item>
                 <Form.Item
                   name="commands"
-                  label={
-                    <Space size={4}>
-                      {__('Enabled Commands')}
-                      <Tooltip title={__('These commands control what the user can do inside Bit File Manager only. They don\'t grant or change WordPress capabilities or the user\'s role.')}>
-                        <QuestionCircleOutlined />
-                      </Tooltip>
-                    </Space>
-                  }
+                  label={__('Enabled Commands')}
+                  tooltip={__(
+                    "These commands control what the user can do inside Bit File Manager only. They don't grant or change WordPress capabilities or the user's role."
+                  )}
                 >
                   <Select mode="multiple">
                     {commands?.map(command => (

--- a/frontend/src/pages/Permissions/ui/Permissions.tsx
+++ b/frontend/src/pages/Permissions/ui/Permissions.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { DeleteFilled } from '@ant-design/icons'
 import { __, sprintf } from '@common/helpers/i18nwrap'
+import { resolveNotification } from '@common/notificationInstance'
 import { type PermissionsSettingsType, type User } from '@pages/Permissions/PermissionsSettingsTypes'
 import useDeleteUserPermission from '@pages/Permissions/data/useDeleteUserPermission'
 import useFetchPermissionsSettings from '@pages/Permissions/data/useFetchPermissionsSettings'
@@ -17,8 +18,7 @@ import {
   Space,
   Switch,
   Tooltip,
-  Typography,
-  notification
+  Typography
 } from 'antd'
 
 import AddUserPermissionModal from './AddUserPermissionModal'
@@ -40,7 +40,7 @@ function Permissions() {
   const handleSubmit = (changedValues: PermissionsSettingsType) => {
     updatePermission(changedValues).then(response => {
       if (response.code === 'SUCCESS') {
-        notification.success({ message: response.message })
+        resolveNotification().success({ message: response.message })
         const updatedFields = form.getFieldsError().map(field => {
           if (field.errors) {
             field.errors = []
@@ -55,7 +55,9 @@ function Permissions() {
             name: field.split('.'),
             errors: response.data[field] as string[]
           })
-          notification.error({ message: response?.message ?? __('Failed to update permission') })
+          resolveNotification().error({
+            message: response?.message ?? __('Failed to update permission')
+          })
         })
         form.setFields(fieldErrors)
       }
@@ -65,10 +67,10 @@ function Permissions() {
   const handleDelete = (user: User) => {
     deletePermission(user.ID).then(response => {
       if (response.code === 'SUCCESS') {
-        notification.success({ message: response?.message ?? __('User permission removed') })
+        resolveNotification().success({ message: response?.message ?? __('User permission removed') })
         refetch()
       } else {
-        notification.error({ message: response?.message ?? __('Failed to remove permission') })
+        resolveNotification().error({ message: response?.message ?? __('Failed to remove permission') })
       }
     })
   }

--- a/frontend/src/pages/Settings/ui/Settings.tsx
+++ b/frontend/src/pages/Settings/ui/Settings.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
 
 import { __ } from '@common/helpers/i18nwrap'
+import { resolveNotification } from '@common/notificationInstance'
 import useFetchSettings from '@pages/Settings/data/useFetchSettings'
 import useUpdateSettings from '@pages/Settings/data/useUpdateSettings'
 import { type SettingsType } from '@pages/Settings/settingsTypes'
-import { Button, Card, Form, Input, Select, Space, Switch, notification } from 'antd'
+import { Button, Card, Form, Input, Select, Space, Switch } from 'antd'
 
 export default function Settings() {
   const { useForm } = Form
@@ -30,7 +31,7 @@ export default function Settings() {
   const handleSubmit = (changedValues: SettingsType) => {
     updateSettings(changedValues).then(response => {
       if (response.code === 'SUCCESS') {
-        notification.success({ message: response.message })
+        resolveNotification().success({ message: response.message })
         const updatedFields = form.getFieldsError().map(field => {
           if (field.errors) {
             field.errors = []

--- a/frontend/src/pages/root/helpers/configureElFinder.ts
+++ b/frontend/src/pages/root/helpers/configureElFinder.ts
@@ -39,6 +39,9 @@ export default function configureElFinder(finderRef: RefObject<HTMLDivElement>):
     theme: THEME,
     lang: LANG,
     cssAutoLoad: getOptionVariable('cssAutoLoad'),
+    // Keep elFinder off the URL hash — the SPA HashRouter owns it. Its own
+    // toolbar back/forward uses an internal history stack, so it stays intact.
+    useBrowserHistory: false,
     contextmenu: getOptionVariable('contextmenu'),
     requestType: getOptionVariable('requestType'),
     themes,

--- a/frontend/src/pages/root/helpers/configureElFinder.ts
+++ b/frontend/src/pages/root/helpers/configureElFinder.ts
@@ -4,6 +4,7 @@ import config, { getOptionVariable } from '@config/config'
 import { installAutoHeight, resolveInitialHeight } from '@lib/elfinder/autoHeight'
 import { elevateDialogLayers, injectDockStyles, watchForBottomTray } from '@lib/elfinder/dialogElevation'
 import registerEmailtoCommand from '@lib/elfinder/emailtoCommand'
+import bridgeElFinderNotifications from '@lib/elfinder/notificationBridge'
 import {
   applyAppendToBodyDefault,
   patchCodeMirror,
@@ -96,6 +97,7 @@ export default function configureElFinder(finderRef: RefObject<HTMLDivElement>):
   patchCodeMirror(finder)
   elevateDialogLayers(jq)
   injectDockStyles()
+  bridgeElFinderNotifications(finder)
   finder.bind('load', watchForBottomTray)
 
   // Intercept dblclick: open text/code files in the editor instead of downloading

--- a/frontend/src/types/finder.d.ts
+++ b/frontend/src/types/finder.d.ts
@@ -29,14 +29,6 @@ declare module 'elfinder' {
     addCommand(commandName: string, commandOptions?: CommandOptions): void
     removeCommand(commandName: string): void
     exec(cmd: string, files?: Array<File> | string, opts?, dstHash?): void
-    toast({
-      mode,
-      msg,
-      hideDuration
-    }: {
-      mode: 'error' | 'warnning' | 'success'
-      msg: string
-      hideDuration: number
-    }): void
+    toast(options: Record<string, unknown>): unknown
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-visitor-keys": "^5.0.1",
     "gettext-parser": "^9.0.2",
     "globals": "^17.6.0",
+    "jsdom": "^29.1.1",
     "lefthook": "^2.1.6",
     "lodash": "^4.18.1",
     "onchange": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-manager",
-  "version": "6.8.9",
+  "version": "6.9.0",
   "description": "Manage your file the way you like. You can upload, delete, copy, move, rename, compress, extract files. You don't need to worry about ftp. It is really simple and easy to use.",
   "author": "Bit Apps",
   "license": "GPL-2.0-or-later",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
@@ -239,7 +242,7 @@ importers:
         version: 4.1.0(vite@8.0.13(@types/node@18.19.130)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(terser@5.47.1))
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@18.19.130)(vite@8.0.13(@types/node@18.19.130)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(terser@5.47.1))
+        version: 4.1.6(@types/node@18.19.130)(jsdom@29.1.1)(vite@8.0.13(@types/node@18.19.130)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(terser@5.47.1))
       zip-local:
         specifier: ^0.3.5
         version: 0.3.5
@@ -292,6 +295,21 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -800,6 +818,10 @@ packages:
   '@blakeembrey/template@1.2.0':
     resolution: {integrity: sha512-w/63nURdkRPpg3AXbNr7lPv6HgOuVDyefTumiXsbXxtIwcuk5EXayWR5OpSwDjsQPgaYsfUSedMduaNOjAYY8A==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cacheable/memory@2.0.8':
     resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
 
@@ -887,8 +909,19 @@ packages:
       conventional-commits-parser:
         optional: true
 
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
   '@csstools/css-calc@3.2.1':
     resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -1191,6 +1224,15 @@ packages:
   '@eslint/plugin-kit@0.7.1':
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2805,6 +2847,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -3039,6 +3084,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -3070,6 +3119,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -3160,6 +3212,10 @@ packages:
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -3731,6 +3787,10 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
@@ -3915,6 +3975,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -4020,6 +4083,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4504,6 +4576,9 @@ packages:
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4862,6 +4937,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -5155,6 +5234,9 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5209,12 +5291,27 @@ packages:
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
+  tldts-core@7.4.6:
+    resolution: {integrity: sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==}
+
+  tldts@7.4.6:
+    resolution: {integrity: sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -5276,6 +5373,10 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -5452,8 +5553,24 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -5572,6 +5689,13 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5673,6 +5797,26 @@ snapshots:
       ajv: 8.20.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6341,6 +6485,10 @@ snapshots:
 
   '@blakeembrey/template@1.2.0': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cacheable/memory@2.0.8':
     dependencies:
       '@cacheable/utils': 2.4.1
@@ -6469,8 +6617,17 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
+  '@csstools/color-helpers@6.1.0': {}
+
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -6717,6 +6874,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8200,6 +8359,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.14:
@@ -8443,6 +8606,13 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -8470,6 +8640,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -8564,6 +8736,8 @@ snapshots:
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -9292,6 +9466,12 @@ snapshots:
 
   hookified@2.2.0: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-tags@5.1.0: {}
 
   iconv-lite@0.6.3:
@@ -9447,6 +9627,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.9
@@ -9539,6 +9721,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -10021,6 +10229,10 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -10402,6 +10614,10 @@ snapshots:
   sax@1.6.0:
     optional: true
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   scroll-into-view-if-needed@3.1.0:
@@ -10768,6 +10984,8 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
@@ -10819,11 +11037,25 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
+  tldts-core@7.4.6: {}
+
+  tldts@7.4.6:
+    dependencies:
+      tldts-core: 7.4.6
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.6
+
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -10921,6 +11153,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@5.26.5: {}
+
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -11024,7 +11258,7 @@ snapshots:
       stylus: 0.62.0
       terser: 5.47.1
 
-  vitest@4.1.6(@types/node@18.19.130)(vite@8.0.13(@types/node@18.19.130)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(terser@5.47.1)):
+  vitest@4.1.6(@types/node@18.19.130)(jsdom@29.1.1)(vite@8.0.13(@types/node@18.19.130)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(terser@5.47.1)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@18.19.130)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(terser@5.47.1))
@@ -11048,6 +11282,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.130
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
@@ -11067,7 +11302,23 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@7.1.0:
     dependencies:
@@ -11267,6 +11518,10 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: file manager, wp file manager, wordpress file manager, files, ftp
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 6.8.9
+Stable tag: 6.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -337,6 +337,12 @@ This plugin sends data to external services for certain features. Below is a sum
 * Privacy: https://pixoeditor.com/privacy-policy/
 
 == Changelog ==
+
+= 6.9 =
+- New: Per-user permissions are now enforced per target path across all volumes, with clearer file-manager-only scope hints
+- Fix: WordPress admin submenu now stays highlighted on the active page (Home, Logs, Settings, Permissions, etc.)
+- Fix: File manager no longer overwrites the browser URL, so in-app navigation stays intact
+- Fix: Popup dialogs now layer above the WordPress admin menu and toolbar
 
 = 6.8.9 =
 - Fix: Minimized editor windows now appear as a floating dock at the bottom of the screen

--- a/tests/BindKeyNormalizationTest.php
+++ b/tests/BindKeyNormalizationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitApps\FM\Tests;
+
+use BitApps\FM\Providers\FileManager\Options;
+use PHPUnit\Framework\TestCase;
+
+class BindKeyNormalizationTest extends TestCase
+{
+    public function testCollapsesNewlinesAndIndentationToSingleSpaces(): void
+    {
+        $input = "get.pre put.pre file.pre\n             mkfile.pre zipdl.pre\n             reload.pre";
+
+        $this->assertSame(
+            'get.pre put.pre file.pre mkfile.pre zipdl.pre reload.pre',
+            Options::normalizeBindKey($input)
+        );
+    }
+
+    public function testTrimsAndCollapsesRepeatedSpaces(): void
+    {
+        $this->assertSame('a.pre b.pre', Options::normalizeBindKey("  a.pre    b.pre  "));
+    }
+
+    public function testEveryTokenIsWhitespaceFree(): void
+    {
+        $key = Options::normalizeBindKey("mkfile.pre\n zipdl.pre");
+        foreach (explode(' ', $key) as $token) {
+            $this->assertSame($token, trim($token));
+            $this->assertStringNotContainsString("\n", $token);
+        }
+    }
+}

--- a/tests/CheckPermissionStrictTest.php
+++ b/tests/CheckPermissionStrictTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitApps\FM\Tests;
+
+use BitApps\FM\Providers\AccessControlProvider;
+use BitApps\FM\Providers\PermissionsProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+
+// Partial mocks (disabled ctor, stubbed getters) carry no ->expects(); opt out of
+// PHPUnit 13's "mock without expectations" notice so test output stays pristine.
+#[AllowMockObjectsWithoutExpectations]
+class CheckPermissionStrictTest extends TestCase
+{
+    /** @return AccessControlProvider */
+    private function accessControl(): AccessControlProvider
+    {
+        // disableOriginalConstructor avoids Plugin::instance()->preferences() in ctor.
+        return $this->getMockBuilder(AccessControlProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+    }
+
+    private function permissions(array $pathToCommands): PermissionsProvider
+    {
+        $mock = $this->getMockBuilder(PermissionsProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getEnabledCommandsForPath'])
+            ->getMock();
+
+        $mock->method('getEnabledCommandsForPath')
+            ->willReturnCallback(static function (string $path) use ($pathToCommands): array {
+                return $pathToCommands[$path] ?? [];
+            });
+
+        return $mock;
+    }
+
+    public function testCommandAllowedWhenPresentForAllPaths(): void
+    {
+        $access = $this->accessControl();
+        $perms  = $this->permissions(['/f/a.txt' => ['download', 'edit']]);
+
+        $this->assertTrue($access->isCommandAllowedForPaths('edit', ['/f/a.txt'], $perms));
+    }
+
+    public function testCommandDeniedWhenMissingForAnyPath(): void
+    {
+        $access = $this->accessControl();
+        $perms  = $this->permissions([
+            '/f/a.txt'   => ['download'],       // per-user: download only
+            '/other.txt' => ['edit', 'upload'], // role
+        ]);
+
+        // 'edit' allowed for /other.txt but NOT for /f/a.txt -> overall denied.
+        $this->assertFalse($access->isCommandAllowedForPaths('edit', ['/f/a.txt', '/other.txt'], $perms));
+    }
+
+    public function testWildcardAllowsAnyCommand(): void
+    {
+        $access = $this->accessControl();
+        $perms  = $this->permissions(['/x' => ['*']]);
+
+        $this->assertTrue($access->isCommandAllowedForPaths('rm', ['/x'], $perms));
+    }
+
+    public function testEmptyPathsIsUnconstrained(): void
+    {
+        $access = $this->accessControl();
+        $perms  = $this->permissions([]);
+
+        $this->assertTrue($access->isCommandAllowedForPaths('rm', [], $perms));
+    }
+
+    public function testResolveInvolvedPathsCollectsTargetTargetsAndDst(): void
+    {
+        $access = $this->accessControl();
+
+        $volume = new class {
+            public function getPath($hash)
+            {
+                return '/resolved/' . $hash;
+            }
+        };
+        $elfinder = new class($volume) {
+            private $volume;
+            public function __construct($volume)
+            {
+                $this->volume = $volume;
+            }
+            public function getVolume($hash)
+            {
+                return $this->volume;
+            }
+        };
+
+        $paths = $access->resolveInvolvedPaths(
+            ['target' => 'h1', 'targets' => ['h2', 'h3'], 'dst' => 'h4'],
+            $elfinder
+        );
+
+        sort($paths);
+        $this->assertSame(
+            ['/resolved/h1', '/resolved/h2', '/resolved/h3', '/resolved/h4'],
+            $paths
+        );
+    }
+}

--- a/tests/CheckPermissionStrictTest.php
+++ b/tests/CheckPermissionStrictTest.php
@@ -108,4 +108,35 @@ class CheckPermissionStrictTest extends TestCase
             $paths
         );
     }
+
+    public function testResolveInvolvedPathsIncludesUploadPathDestinations(): void
+    {
+        $access = $this->accessControl();
+
+        $volume = new class {
+            public function getPath($hash)
+            {
+                return '/resolved/' . $hash;
+            }
+        };
+        $elfinder = new class($volume) {
+            private $volume;
+            public function __construct($volume)
+            {
+                $this->volume = $volume;
+            }
+            public function getVolume($hash)
+            {
+                return $this->volume;
+            }
+        };
+
+        $paths = $access->resolveInvolvedPaths(
+            ['target' => 'h1', 'upload_path' => ['h2', 'h3']],
+            $elfinder
+        );
+
+        sort($paths);
+        $this->assertSame(['/resolved/h1', '/resolved/h2', '/resolved/h3'], $paths);
+    }
 }

--- a/tests/CheckPermissionStrictTest.php
+++ b/tests/CheckPermissionStrictTest.php
@@ -75,17 +75,17 @@ class CheckPermissionStrictTest extends TestCase
         $this->assertTrue($access->isCommandAllowedForPaths('rm', [], $perms));
     }
 
-    public function testResolveInvolvedPathsCollectsTargetTargetsAndDst(): void
+    /** elFinder stub whose getVolume() resolves any hash to "/resolved/{hash}". */
+    private function elfinderStub(): object
     {
-        $access = $this->accessControl();
-
         $volume = new class {
             public function getPath($hash)
             {
                 return '/resolved/' . $hash;
             }
         };
-        $elfinder = new class($volume) {
+
+        return new class($volume) {
             private $volume;
             public function __construct($volume)
             {
@@ -96,10 +96,15 @@ class CheckPermissionStrictTest extends TestCase
                 return $this->volume;
             }
         };
+    }
+
+    public function testResolveInvolvedPathsCollectsTargetTargetsAndDst(): void
+    {
+        $access = $this->accessControl();
 
         $paths = $access->resolveInvolvedPaths(
             ['target' => 'h1', 'targets' => ['h2', 'h3'], 'dst' => 'h4'],
-            $elfinder
+            $this->elfinderStub()
         );
 
         sort($paths);
@@ -113,27 +118,9 @@ class CheckPermissionStrictTest extends TestCase
     {
         $access = $this->accessControl();
 
-        $volume = new class {
-            public function getPath($hash)
-            {
-                return '/resolved/' . $hash;
-            }
-        };
-        $elfinder = new class($volume) {
-            private $volume;
-            public function __construct($volume)
-            {
-                $this->volume = $volume;
-            }
-            public function getVolume($hash)
-            {
-                return $this->volume;
-            }
-        };
-
         $paths = $access->resolveInvolvedPaths(
             ['target' => 'h1', 'upload_path' => ['h2', 'h3']],
-            $elfinder
+            $this->elfinderStub()
         );
 
         sort($paths);

--- a/tests/EnabledCommandsForPathTest.php
+++ b/tests/EnabledCommandsForPathTest.php
@@ -98,4 +98,35 @@ class EnabledCommandsForPathTest extends TestCase
 
         $this->assertSame(['edit'], $provider->getEnabledCommandsForPath(__DIR__ . '/x'));
     }
+
+    public function testNonexistentChildUnderUserFolderStaysUser(): void
+    {
+        WP_Mock::userFunction('is_user_logged_in', ['return' => true]);
+
+        $provider = $this->provider([
+            'getGuestPermissions'        => ['commands' => [], 'path' => ''],
+            'isCurrentUserHasPermission' => true,
+            'permissionsForCurrentUser'  => ['commands' => ['download'], 'path' => __DIR__],
+            'permissionsForCurrentRole'  => ['commands' => ['edit'], 'path' => '/role'],
+        ]);
+
+        // Nonexistent child of the real tests/ dir -> parent realpaths to __DIR__ -> under F.
+        $this->assertSame(['download'], $provider->getEnabledCommandsForPath(__DIR__ . '/no-such-file.txt'));
+    }
+
+    public function testTraversalOutOfUserFolderFallsBackToRole(): void
+    {
+        WP_Mock::userFunction('is_user_logged_in', ['return' => true]);
+
+        $provider = $this->provider([
+            'getGuestPermissions'        => ['commands' => [], 'path' => ''],
+            'isCurrentUserHasPermission' => true,
+            'permissionsForCurrentUser'  => ['commands' => ['download'], 'path' => __DIR__],
+            'permissionsForCurrentRole'  => ['commands' => ['edit'], 'path' => '/role'],
+        ]);
+
+        // Raw '..' path whose real parent (repo root, dirname(dirname(__DIR__))) is OUTSIDE F.
+        $escaping = __DIR__ . '/../../no-such-file.txt';
+        $this->assertSame(['edit'], $provider->getEnabledCommandsForPath($escaping));
+    }
 }

--- a/tests/EnabledCommandsForPathTest.php
+++ b/tests/EnabledCommandsForPathTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitApps\FM\Tests;
+
+use BitApps\FM\Providers\PermissionsProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+#[AllowMockObjectsWithoutExpectations]
+class EnabledCommandsForPathTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        WP_Mock::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        WP_Mock::tearDown();
+    }
+
+    /** @return PermissionsProvider&\PHPUnit\Framework\MockObject\MockObject */
+    private function provider(array $methods)
+    {
+        $mock = $this->getMockBuilder(PermissionsProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(array_keys($methods))
+            ->getMock();
+
+        foreach ($methods as $name => $return) {
+            $mock->method($name)->willReturn($return);
+        }
+
+        return $mock;
+    }
+
+    public function testLoggedOutReturnsGuestCommands(): void
+    {
+        WP_Mock::userFunction('is_user_logged_in', ['return' => false]);
+
+        $provider = $this->provider([
+            'getGuestPermissions'         => ['commands' => ['download'], 'path' => '/pub'],
+            'isCurrentUserHasPermission'  => false,
+            'permissionsForCurrentUser'   => ['commands' => [], 'path' => ''],
+            'permissionsForCurrentRole'   => ['commands' => ['edit'], 'path' => '/role'],
+            'currentUserID'               => 0,
+        ]);
+
+        $this->assertSame(['download'], $provider->getEnabledCommandsForPath('/pub/x'));
+    }
+
+    public function testPathUnderUserFolderReturnsUserCommands(): void
+    {
+        WP_Mock::userFunction('is_user_logged_in', ['return' => true]);
+
+        $provider = $this->provider([
+            'getGuestPermissions'        => ['commands' => [], 'path' => ''],
+            'isCurrentUserHasPermission' => true,
+            'permissionsForCurrentUser'  => ['commands' => ['download'], 'path' => __DIR__],
+            'permissionsForCurrentRole'  => ['commands' => ['edit', 'upload'], 'path' => '/role'],
+            'currentUserID'              => 7,
+        ]);
+
+        // __DIR__ exists so realpath() resolves; a child path is under it.
+        $child = __DIR__ . '/child.txt';
+        $this->assertSame(['download'], $provider->getEnabledCommandsForPath($child));
+    }
+
+    public function testPathOutsideUserFolderReturnsRoleCommands(): void
+    {
+        WP_Mock::userFunction('is_user_logged_in', ['return' => true]);
+
+        $provider = $this->provider([
+            'getGuestPermissions'        => ['commands' => [], 'path' => ''],
+            'isCurrentUserHasPermission' => true,
+            'permissionsForCurrentUser'  => ['commands' => ['download'], 'path' => __DIR__],
+            'permissionsForCurrentRole'  => ['commands' => ['edit', 'upload'], 'path' => '/role'],
+            'currentUserID'              => 7,
+        ]);
+
+        $this->assertSame(['edit', 'upload'], $provider->getEnabledCommandsForPath('/somewhere/else'));
+    }
+
+    public function testNoPerUserConfigReturnsRoleCommands(): void
+    {
+        WP_Mock::userFunction('is_user_logged_in', ['return' => true]);
+
+        $provider = $this->provider([
+            'getGuestPermissions'        => ['commands' => [], 'path' => ''],
+            'isCurrentUserHasPermission' => false,
+            'permissionsForCurrentUser'  => ['commands' => [], 'path' => ''],
+            'permissionsForCurrentRole'  => ['commands' => ['edit'], 'path' => '/role'],
+            'currentUserID'              => 7,
+        ]);
+
+        $this->assertSame(['edit'], $provider->getEnabledCommandsForPath(__DIR__ . '/x'));
+    }
+}

--- a/tests/PathBoundaryTest.php
+++ b/tests/PathBoundaryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitApps\FM\Tests;
+
+use BitApps\FM\Providers\PermissionsProvider;
+use PHPUnit\Framework\TestCase;
+
+class PathBoundaryTest extends TestCase
+{
+    public function testExactPathIsUnderBoundary(): void
+    {
+        $this->assertTrue(PermissionsProvider::isSubPath('/var/www/f', '/var/www/f'));
+    }
+
+    public function testNestedChildIsUnderBoundary(): void
+    {
+        $this->assertTrue(PermissionsProvider::isSubPath('/var/www/f/sub/a.txt', '/var/www/f'));
+    }
+
+    public function testTrailingSeparatorIsIgnored(): void
+    {
+        $this->assertTrue(PermissionsProvider::isSubPath('/var/www/f/', '/var/www/f'));
+        $this->assertTrue(PermissionsProvider::isSubPath('/var/www/f/sub', '/var/www/f/'));
+    }
+
+    public function testSiblingWithSharedPrefixIsNotUnderBoundary(): void
+    {
+        $this->assertFalse(PermissionsProvider::isSubPath('/var/www/foobar', '/var/www/foo'));
+    }
+
+    public function testUnrelatedPathIsNotUnderBoundary(): void
+    {
+        $this->assertFalse(PermissionsProvider::isSubPath('/etc/passwd', '/var/www/f'));
+    }
+
+    public function testEmptyBoundaryIsNeverUnder(): void
+    {
+        $this->assertFalse(PermissionsProvider::isSubPath('/var/www/f', ''));
+    }
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -41,6 +41,7 @@ const getVersion = () => {
   return version
 }
 
+
 // @ts-ignore
 export default defineConfig(({ mode }) => {
   if (mode === 'loader') {
@@ -106,7 +107,16 @@ export default defineConfig(({ mode }) => {
         plugins: [csso()]
       }
     },
-    resolve: { alias: readAliasFromTsConfig() },
+    resolve: {
+      alias: [
+        ...readAliasFromTsConfig(),
+        // Vitest only: antd's CJS lib/ build uses es/ subpaths that fail under Node's ESM
+        // resolver (extensionless imports like @rc-component/util/es/ref). Force the ESM
+        // es/ build so every import goes through __vite_ssr_import__ and Vite's resolver,
+        // which adds the .js extension and handles the whole chain without patches.
+        ...(process.env.VITEST ? [{ find: /^antd$/, replacement: 'antd/es/index' }] : []),
+      ],
+    },
 
     build: {
       outDir: '../../assets/js',
@@ -158,11 +168,13 @@ export default defineConfig(({ mode }) => {
       }
     },
     test: {
-      // globals: true,
       environment: 'jsdom',
-      setupFiles: './config/test.setup.ts'
-      // since parsing CSS is slow
-      // css: true,
+      setupFiles: './config/test.setup.ts',
+      server: {
+        deps: {
+          inline: ['antd', /@rc-component/, /@ant-design\/icons/]
+        }
+      }
     },
     server: {
       cors: true, // required to load scripts from custom host

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -217,10 +217,13 @@ function setDevServerConfig(): Plugin {
           }
         })
 
-        // Clean up the port file on real process exit, not on the server 'close'
-        // event — that also fires on server.restart() and would race-delete the
-        // restarted server's port file. Watcher left to vite (closing it orphans HMR).
+        // Clean up the port file on shutdown so the plugin falls back to prod
+        // assets. 'exit' misses Ctrl+C/kill, so SIGINT/SIGTERM go through
+        // process.exit() (which fires 'exit'). Not on 'close' — that also fires
+        // on server.restart() and would race-delete the fresh port file.
         process.once('exit', removeStoredPort)
+        process.once('SIGINT', () => process.exit())
+        process.once('SIGTERM', () => process.exit())
       }
     }
   }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -41,7 +41,6 @@ const getVersion = () => {
   return version
 }
 
-
 // @ts-ignore
 export default defineConfig(({ mode }) => {
   if (mode === 'loader') {
@@ -218,10 +217,10 @@ function setDevServerConfig(): Plugin {
           }
         })
 
-        server.httpServer.close(() => {
-          server.watcher.close()
-          removeStoredPort()
-        })
+        // Clean up the port file on real process exit, not on the server 'close'
+        // event — that also fires on server.restart() and would race-delete the
+        // restarted server's port file. Watcher left to vite (closing it orphans HMR).
+        process.once('exit', removeStoredPort)
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Notifications** — all elFinder toasts/errors and page notices now flow through one context-aware antd instance, fixing notices that rendered behind the WP admin shell (z-index trap). elFinder i18n HTML is flattened to XSS-safe plain text, and error notices persist until dismissed instead of being evicted by transient toasts.
- **Permission errors** — technical `run this command [ edit ]` text replaced with human-readable actions ("You don't have permission to edit files here."), owned by `PermissionsProvider`.
- **Dev-server security** — the vite dev port is read and validated in `Config::devPort()` (int-cast + privileged-port floor + prod fallback), closing a script-src injection vector via the `port` file. Port-file lifecycle and HMR watcher orphaning fixed in `vite.config.mts`.
- **Thumbnail exposure** — elFinder's `.tmb` cache is disabled; it was created under the web-served volume root, leaking downscaled copies past the permission gate.
- **Confinement** — per-user/role volume disabled-command hints and path-boundary validation backing the strict permission gate.

## Test plan
- Frontend: `notificationBridge` unit tests (9) green; `tsc` + eslint clean.
- Backend: `php -l` + phpcs clean on changed regions.
- Live-verified in WP admin: notices render above the shell at z-index 11050; error survives a toast burst; elFinder messages render decoded/clean; dev bundle loads via `Config::devPort()`; no elFinder `mkdir` warning; thumbnails off (`tmbUrl` empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)