### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       PLUGIN_SLUG: file-manager
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup PHP
         id: setup-php
@@ -27,7 +27,7 @@ jobs:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           run_install: false
 
@@ -41,7 +41,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@v6.1.0
         name: Setup package cache
         with:
           path: |
@@ -99,8 +99,9 @@ jobs:
 
       - name: Upload release asset
         if: steps.build-plugin.outputs.free_exists == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          tag_name: ${{ github.event.release.tag_name }}
           files: ${{ steps.deploy.outputs['zip-path'] }}

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 
@@ -35,7 +35,7 @@ jobs:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           run_install: false
 
@@ -50,7 +50,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Setup package cache
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ${{ steps.pnpm-cache.outputs.dir }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 
@@ -30,7 +30,7 @@ jobs:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           run_install: false
 
@@ -44,7 +44,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v5.0.5
+      - uses: actions/cache/restore@v6.1.0
         name: Restore package cache
         id: restore-package-cache
         with:
@@ -61,7 +61,7 @@ jobs:
           composer install --prefer-dist --no-progress
           pnpm install
       
-      - uses: actions/cache/save@v5.0.5
+      - uses: actions/cache/save@v6.1.0
         name: Save package cache
         if: always() && steps.restore-package-cache.outputs.cache-hit != 'true'
         with:


### PR DESCRIPTION
## Summary
Bumps CI actions to their latest releases and fixes the WordPress.org deploy's release-asset step.

| action | before | after |
|---|---|---|
| `actions/checkout` | v6.0.2 | **v7.0.0** |
| `pnpm/action-setup` | v6.0.8 | **v6.0.9** |
| `actions/cache` (+ `restore`/`save`) | v5.0.5 | **v6.1.0** |
| `softprops/action-gh-release` | v2 | **v3** |

Left as-is (already latest / floating): `actions/setup-node@v6.4.0`, `shivammathur/setup-php@v2`, `wordpress/plugin-check-action@v1`, `10up/action-wordpress-plugin-deploy@stable`.

## Deploy fix
The `6.9` release deploy failed at **Upload release asset** with `⚠️ GitHub Releases requires a tag`. The SVN deploy to wordpress.org succeeded; only the GitHub-release zip attachment failed — `action-gh-release` couldn't derive the tag from the release-event ref (`refs/heads/main`) and no `tag_name` was set. This PR passes `tag_name: ${{ github.event.release.tag_name }}` explicitly and bumps the action to v3.

## Notes
- Major bumps (checkout v7, cache v6, gh-release v3) require the Node 24 runner (default) — no workflow syntax changes needed.
- Separate from the feature PR #16 (this touches only CI infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)